### PR TITLE
eos-shard-writer: Fix where we write blob entries

### DIFF
--- a/src/eos-shard-writer.c
+++ b/src/eos-shard-writer.c
@@ -239,7 +239,7 @@ eos_shard_writer_write (EosShardWriter *self, char *path)
   header_size = htole64 (header_size);
   g_variant_unref (variant);
 
-  lseek (fd, ALIGN (header_size), SEEK_SET);
+  lseek (fd, ALIGN (sizeof (header_size) + header_size), SEEK_SET);
 
   int i;
   for (i = 0; i < self->entries->len; i++) {


### PR DESCRIPTION
In commit 6633a84, I removed data_offs, but forgot to adjust the math of
where we stored the files to adjust for the header_size field, which is
part of our simple GVariant wrapper.

As such, if we were close enough to our alignment boundary, the header
would stomp on file contents, giving incorrect contents.

[endlessm/eos-sdk#3210]
