### PR TITLE
eos-shard-shard-file: Fix find_record_by_raw_name

### DIFF
--- a/src/eos-shard-shard-file.c
+++ b/src/eos-shard-shard-file.c
@@ -265,11 +265,14 @@ eos_shard_shard_file_find_record_by_raw_name (EosShardShardFile *self, uint8_t *
 {
   EosShardRecord key = { .raw_name = raw_name };
   EosShardRecord *keyp = &key;
+  EosShardRecord **res;
 
-  return bsearch (&keyp,
-                  self->records, self->n_records,
-                  sizeof (EosShardRecord *),
-                  eos_shard_record_entry_cmp);
+  res = bsearch (&keyp,
+                 self->records, self->n_records,
+                 sizeof (EosShardRecord *),
+                 eos_shard_record_entry_cmp);
+
+  return eos_shard_record_ref (*res);
 }
 
 /**


### PR DESCRIPTION
Ever since the GVariant conversion in e291724, we store
EosShardRecord _s in our internal array, not EosShardRecord entries
directly. The bsearch API returns a pointer into our array, so we
effectively have an EosShardRecord *_, which we have to dereference
before we can pull out the EosShardRecord *.

We also need to make sure we ref it before we return it to gjs, so it
won't free the record accidentally.

[endlessm/eos-sdk#3217]
