### PR TITLE
record: Throw an error instead of failing an assert for a botched record

### DIFF
--- a/src/eos-shard-blob.c
+++ b/src/eos-shard-blob.c
@@ -159,7 +159,8 @@ _eos_shard_blob_new_for_variant (EosShardShardFile           *shard_file,
                  &blob->size,
                  &blob->uncompressed_size);
   checksum = g_variant_get_fixed_array (checksum_variant, &n_elts, 1);
-  g_assert (n_elts == 32);
+  if (n_elts != 32)
+    return NULL;
   blob->checksum = g_memdup (checksum, 32);
   return blob;
 }

--- a/src/eos-shard-record.c
+++ b/src/eos-shard-record.c
@@ -104,11 +104,23 @@ _eos_shard_record_new_for_variant (EosShardShardFile *shard_file, GVariant *reco
                  &metadata_variant,
                  &data_variant);
   raw_name = g_variant_get_fixed_array (raw_name_variant, &n_elts, 1);
-  g_assert (n_elts == EOS_SHARD_RAW_NAME_SIZE);
+  if (n_elts != EOS_SHARD_RAW_NAME_SIZE)
+    goto corrupt;
+
   record->raw_name = g_memdup (raw_name, EOS_SHARD_RAW_NAME_SIZE);
   record->metadata = _eos_shard_blob_new_for_variant (shard_file, metadata_variant);
+  if (!record->metadata)
+    goto corrupt;
+
   record->data = _eos_shard_blob_new_for_variant (shard_file, data_variant);
+  if (!record->data)
+    goto corrupt;
+
   return record;
+
+ corrupt:
+  eos_shard_record_unref (record);
+  return NULL;
 }
 
 G_DEFINE_BOXED_TYPE (EosShardRecord, eos_shard_record,


### PR DESCRIPTION
If a record's name isn't the correct size, return a corruption error
rather than killing the entire process.

[endlessm/eos-sdk#3239]
