### PR TITLE
blob: Expose get_offset

### DIFF
--- a/src/eos-shard-blob-stream.c
+++ b/src/eos-shard-blob-stream.c
@@ -150,7 +150,7 @@ eos_shard_blob_stream_read (GInputStream  *stream,
   int read_error;
   goffset blob_offset;
 
-  blob_offset = _eos_shard_blob_get_offset (self->blob);
+  blob_offset = eos_shard_blob_get_offset (self->blob);
   actual_count = MIN (count, _eos_shard_blob_get_packed_size (self->blob) - self->pos);
 
   size_read = _eos_shard_shard_file_read_data (self->shard_file, buffer, actual_count, blob_offset + self->pos);

--- a/src/eos-shard-blob.c
+++ b/src/eos-shard-blob.c
@@ -106,7 +106,7 @@ _eos_shard_blob_get_packed_size (EosShardBlob *blob)
 }
 
 goffset
-_eos_shard_blob_get_offset (EosShardBlob *blob)
+eos_shard_blob_get_offset (EosShardBlob *blob)
 {
   return blob->offs;
 }

--- a/src/eos-shard-blob.h
+++ b/src/eos-shard-blob.h
@@ -64,6 +64,6 @@ void eos_shard_blob_unref (EosShardBlob *blob);
 
 EosShardBlob * _eos_shard_blob_new_for_variant (EosShardShardFile *shard_file, GVariant *blob_variant);
 gsize _eos_shard_blob_get_packed_size (EosShardBlob *blob);
-goffset _eos_shard_blob_get_offset (EosShardBlob *blob);
+goffset eos_shard_blob_get_offset (EosShardBlob *blob);
 
 #endif /* EOS_SHARD_BLOB_H */


### PR DESCRIPTION
This is required as a value to pass to xapian-bridge.

[endlessm/eos-sdk#3978]
