### PR TITLE
shard-writer: Fix writing too many bytes from DICTIONARY_MAGIC

### DIFF
--- a/src/eos-shard-dictionary-writer.c
+++ b/src/eos-shard-dictionary-writer.c
@@ -153,7 +153,7 @@ eos_shard_dictionary_writer_finish (EosShardDictionaryWriter *self, GError **err
 
   /* Write out our header now that we know where the block table begins. */
   struct dictionary_header header = {};
-  strcpy (header.magic, DICTIONARY_MAGIC);
+  memcpy (header.magic, DICTIONARY_MAGIC, sizeof (header.magic));
   header.block_table_start = block_table_start;
   header.bloom_filter_start = bloom_filter_start;
   g_seekable_seek (G_SEEKABLE (self->stream), 0, G_SEEK_SET, NULL, NULL);


### PR DESCRIPTION
strcpy() was writing 9 bytes into the 8 byte magic field.