### PR TITLE
shard-writer-v2: Fix issues with 64-bit cleanliness

### DIFF
--- a/src/eos-shard-dictionary.c
+++ b/src/eos-shard-dictionary.c
@@ -34,14 +34,14 @@ typedef struct _EosShardDictionary {
   int ref_count;
 
   int fd;
-  int offset;
+  goffset offset;
   struct dictionary_header header;
 
   struct bloom_filter _bloom_filter, *bloom_filter;
 } EosShardDictionary;
 
 static gboolean
-dictionary_open (struct dictionary_header *header, int fd, int offset)
+dictionary_open (struct dictionary_header *header, int fd, goffset offset)
 {
   ssize_t len = pread (fd, header, sizeof (*header), offset);
 
@@ -233,7 +233,7 @@ eos_shard_dictionary_unref (EosShardDictionary *dictionary)
 }
 
 static char *
-read_cstring (int fd, int offset)
+read_cstring (int fd, off_t offset)
 {
   GString *string = g_string_new (NULL);
   ssize_t len;

--- a/src/eos-shard-writer-v2.c
+++ b/src/eos-shard-writer-v2.c
@@ -21,6 +21,8 @@
 
 #include <fcntl.h>
 #include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "eos-shard-shard-file.h"
 #include "eos-shard-format-v2.h"
@@ -281,7 +283,7 @@ write_blob (EosShardWriterV2 *self, int fd, struct eos_shard_writer_v2_blob_entr
   sblob.flags = blob->flags;
 
   blob->offs = lseek (fd, 0, SEEK_CUR);
-  int data_offs = ALIGN (blob->offs + sizeof (sblob));
+  off_t data_offs = ALIGN (blob->offs + sizeof (sblob));
   lseek (fd, data_offs, SEEK_SET);
 
   /* Make room for the blob entry. */
@@ -303,7 +305,7 @@ write_blob (EosShardWriterV2 *self, int fd, struct eos_shard_writer_v2_blob_entr
   sblob.data_start = data_offs;
 
   /* Go back and patch our blob header... */
-  int old_pos = lseek (fd, 0, SEEK_CUR);
+  off_t old_pos = lseek (fd, 0, SEEK_CUR);
   lseek (fd, blob->offs, SEEK_SET);
   g_assert (write (fd, &sblob, sizeof (sblob)) >= 0);
   lseek (fd, old_pos, SEEK_SET);


### PR DESCRIPTION
We need to import unistd.h so that the lseek prototype has off_t, not
int, and we need to never do math with integers, lest we don't allow any
file sizes above INT_MAX.