### PR TITLE
blob: make eos_shard_blob_get_packed_size public

### DIFF
--- a/src/eos-shard-blob-stream.c
+++ b/src/eos-shard-blob-stream.c
@@ -90,7 +90,7 @@ eos_shard_blob_stream_seek (GSeekable *seekable,
   gsize blob_size;
 
   self = EOS_SHARD_BLOB_STREAM (seekable);
-  blob_size = _eos_shard_blob_get_packed_size (self->blob);
+  blob_size = eos_shard_blob_get_packed_size (self->blob);
 
   switch (type) {
     case G_SEEK_CUR:
@@ -153,7 +153,7 @@ eos_shard_blob_stream_read (GInputStream  *stream,
   goffset blob_offset;
 
   blob_offset = eos_shard_blob_get_offset (self->blob);
-  actual_count = MIN (count, _eos_shard_blob_get_packed_size (self->blob) - self->pos);
+  actual_count = MIN (count, eos_shard_blob_get_packed_size (self->blob) - self->pos);
 
   size_read = _eos_shard_shard_file_read_data (self->shard_file, buffer, actual_count, blob_offset + self->pos);
   read_error = errno;

--- a/src/eos-shard-blob.c
+++ b/src/eos-shard-blob.c
@@ -107,7 +107,7 @@ eos_shard_blob_get_flags (EosShardBlob *blob)
 }
 
 gsize
-_eos_shard_blob_get_packed_size (EosShardBlob *blob)
+eos_shard_blob_get_packed_size (EosShardBlob *blob)
 {
   return blob->size;
 }

--- a/src/eos-shard-blob.h
+++ b/src/eos-shard-blob.h
@@ -69,7 +69,7 @@ gsize eos_shard_blob_get_content_size (EosShardBlob *blob);
 EosShardBlob * eos_shard_blob_ref (EosShardBlob *blob);
 void eos_shard_blob_unref (EosShardBlob *blob);
 
-gsize _eos_shard_blob_get_packed_size (EosShardBlob *blob);
+gsize eos_shard_blob_get_packed_size (EosShardBlob *blob);
 goffset eos_shard_blob_get_offset (EosShardBlob *blob);
 
 EosShardDictionary * eos_shard_blob_load_as_dictionary (EosShardBlob *blob, GError **error);


### PR DESCRIPTION
This method is useful for introspecting the on-disk use of space.

https://phabricator.endlessm.com/T13672