### PR TITLE
impl-v1 list_blobs: ref blobs if they exist

### DIFF
--- a/src/eos-shard-shard-file-impl-v1.c
+++ b/src/eos-shard-shard-file-impl-v1.c
@@ -245,8 +245,12 @@ static GSList *
 list_blobs (EosShardShardFileImpl *impl, EosShardRecord *record)
 {
   GSList *l = NULL;
-  l = g_slist_prepend (l, record->metadata);
-  l = g_slist_prepend (l, record->data);
+
+  if (record->metadata)
+    l = g_slist_prepend (l, eos_shard_blob_ref (record->metadata));
+  if (record->data)
+    l = g_slist_prepend (l, eos_shard_blob_ref (record->data));
+
   return l;
 }
 


### PR DESCRIPTION
Records aren't guaranteed to have both data and metadata, so only append
them if they exist. Also ref the blobs so they're not freed by the
caller