### PR TITLE
shard: Add implementation of EosShardFile from Eknc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,8 @@ eos_shard_headers = \
 	src/eos-shard-dictionary.h \
 	src/eos-shard-dictionary-writer.h \
 	src/eos-shard-dictionary-format.h \
+	src/eos-shard-file.h \
+	src/eos-shard-file-input-stream-wrapper.h \
 	src/eos-shard-enums.h \
 	src/eos-shard-types.h \
 	$(NULL)
@@ -54,6 +56,8 @@ eos_shard_sources = \
 	src/eos-shard-blob.c \
 	src/eos-shard-blob-stream.c \
 	src/eos-shard-bloom-filter.c \
+	src/eos-shard-file.c \
+	src/eos-shard-file-input-stream-wrapper.c \
 	src/eos-shard-writer-v1.c \
 	src/eos-shard-writer-v2.c \
 	src/eos-shard-dictionary.c \

--- a/src/eos-shard-file-input-stream-wrapper.c
+++ b/src/eos-shard-file-input-stream-wrapper.c
@@ -1,0 +1,260 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+/*
+ * eos-shard-file-input-stream-wrapper.c
+ *
+ * Copyright (C) 2016 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "eos-shard-file-input-stream-wrapper.h"
+
+struct _EosShardFileInputStreamWrapper
+{
+  GFileInputStream parent;
+
+  GInputStream *stream;
+  GFile *file;
+};
+typedef struct _EosShardFileInputStreamWrapper EosShardFileInputStreamWrapper;
+
+enum
+{
+  PROP_0,
+  PROP_STREAM,
+  PROP_FILE,
+  LAST_PROP,
+};
+
+static GParamSpec *obj_props[LAST_PROP];
+
+G_DEFINE_TYPE (EosShardFileInputStreamWrapper,
+               eos_shard_file_input_stream_wrapper,
+               G_TYPE_FILE_INPUT_STREAM)
+
+static void
+eos_shard_file_input_stream_wrapper_dispose (GObject *object)
+{
+  EosShardFileInputStreamWrapper *self = EOS_SHARD_FILE_INPUT_STREAM_WRAPPER (object);
+
+  g_clear_object (&self->stream);
+  g_clear_object (&self->file);
+
+  G_OBJECT_CLASS (eos_shard_file_input_stream_wrapper_parent_class)->dispose (object);
+}
+
+static void
+eos_shard_file_input_stream_wrapper_set_property (GObject          *object,
+                                                  guint             prop_id,
+                                                  const GValue     *value,
+                                                  GParamSpec       *pspec)
+{
+  EosShardFileInputStreamWrapper *self = EOS_SHARD_FILE_INPUT_STREAM_WRAPPER (object);
+
+  switch (prop_id)
+    {
+    case PROP_STREAM:
+      self->stream = g_value_dup_object (value);
+      break;
+    case PROP_FILE:
+      self->file = g_value_dup_object (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+eos_shard_file_input_stream_wrapper_get_property (GObject    *object,
+                                                  guint       prop_id,
+                                                  GValue     *value,
+                                                  GParamSpec *pspec)
+{
+  EosShardFileInputStreamWrapper *self = EOS_SHARD_FILE_INPUT_STREAM_WRAPPER (object);
+
+  switch (prop_id)
+    {
+    case PROP_STREAM:
+      g_value_set_object (value, self->stream);
+      break;
+    case PROP_FILE:
+      g_value_set_object (value, self->file);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+#define return_error_if_fail(expr,code,msg,val) \
+if (!(expr)) \
+  { \
+    g_warning ("%s "#expr" failed", __func__); \
+    g_set_error_literal (error, G_IO_ERROR, code, msg); \
+    return val;\
+  }\
+
+#define return_error_if_no_stream(val) \
+  return_error_if_fail (self->stream, G_IO_ERROR_FAILED, "No input stream to wrap", val)
+
+static gssize
+eos_shard_file_input_stream_wrapper_read (GInputStream  *stream,
+                                          void          *buffer,
+                                          gsize          count,
+                                          GCancellable  *cancellable,
+                                          GError       **error)
+{
+  EosShardFileInputStreamWrapper *self = EOS_SHARD_FILE_INPUT_STREAM_WRAPPER (stream);
+
+  return_error_if_no_stream (-1);
+
+  return g_input_stream_read (self->stream, buffer, count, cancellable, error);
+}
+
+static gboolean
+eos_shard_file_input_stream_wrapper_close (GInputStream  *stream,
+                                           GCancellable  *cancellable,
+                                           GError       **error)
+{
+  EosShardFileInputStreamWrapper *self = EOS_SHARD_FILE_INPUT_STREAM_WRAPPER (stream);
+
+  /* This happens on dispose */
+  if (!self->stream)
+    {
+      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_CLOSED, "Stream already closed");
+      return FALSE;
+    }
+
+  return g_input_stream_close (self->stream, cancellable, error);
+}
+
+static gssize
+eos_shard_file_input_stream_wrapper_skip (GInputStream  *stream,
+                                          gsize          count,
+                                          GCancellable  *cancellable,
+                                          GError       **error)
+{
+  EosShardFileInputStreamWrapper *self = EOS_SHARD_FILE_INPUT_STREAM_WRAPPER (stream);
+
+  return_error_if_no_stream (-1);
+
+  return g_input_stream_skip (self->stream, count, cancellable, error);
+}
+
+static goffset
+eos_shard_file_input_stream_wrapper_tell (GFileInputStream *stream)
+{
+  EosShardFileInputStreamWrapper *self = EOS_SHARD_FILE_INPUT_STREAM_WRAPPER (stream);
+
+  g_return_val_if_fail (self->stream, 0);
+
+  if (!G_IS_SEEKABLE (self->stream))
+    return 0;
+
+  return g_seekable_tell (G_SEEKABLE (self->stream));
+}
+
+static gboolean
+eos_shard_file_input_stream_wrapper_can_seek (GFileInputStream *stream)
+{
+  EosShardFileInputStreamWrapper *self = EOS_SHARD_FILE_INPUT_STREAM_WRAPPER (stream);
+
+  g_return_val_if_fail (self->stream, FALSE);
+
+  return G_IS_SEEKABLE (self->stream) && g_seekable_can_seek (G_SEEKABLE (self->stream));
+}
+
+static gboolean
+eos_shard_file_input_stream_wrapper_seek (GFileInputStream *stream,
+                                          goffset offset,
+                                          GSeekType type,
+                                          GCancellable *cancellable,
+                                          GError **error)
+{
+  EosShardFileInputStreamWrapper *self = EOS_SHARD_FILE_INPUT_STREAM_WRAPPER (stream);
+
+  return_error_if_no_stream (FALSE);
+  return_error_if_fail (G_IS_SEEKABLE (self->stream), G_IO_ERROR_NOT_SUPPORTED,
+                        "Input stream doesn't implement seek", FALSE);
+
+  return g_seekable_seek (G_SEEKABLE (self->stream), offset, type, cancellable, error);
+}
+
+static GFileInfo *
+eos_shard_file_input_stream_wrapper_query_info (GFileInputStream  *stream,
+                                                const char        *attributes,
+                                                GCancellable      *cancellable,
+                                                GError           **error)
+{
+  EosShardFileInputStreamWrapper *self = EOS_SHARD_FILE_INPUT_STREAM_WRAPPER (stream);
+
+  return_error_if_fail (self->file, G_IO_ERROR_FAILED, "No GFile to wrap", NULL);
+
+  return g_file_query_info (self->file, attributes, 0, cancellable, error);
+}
+
+static void
+eos_shard_file_input_stream_wrapper_class_init (EosShardFileInputStreamWrapperClass *klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  GInputStreamClass *istream_class;
+  GFileInputStreamClass *fileistream_klass;
+
+  gobject_class->dispose = eos_shard_file_input_stream_wrapper_dispose;
+  gobject_class->set_property = eos_shard_file_input_stream_wrapper_set_property;
+  gobject_class->get_property = eos_shard_file_input_stream_wrapper_get_property;
+
+  istream_class = G_INPUT_STREAM_CLASS (klass);
+  istream_class->read_fn = eos_shard_file_input_stream_wrapper_read;
+  istream_class->close_fn = eos_shard_file_input_stream_wrapper_close;
+  istream_class->skip = eos_shard_file_input_stream_wrapper_skip;
+
+  fileistream_klass = G_FILE_INPUT_STREAM_CLASS (klass);
+  fileistream_klass->tell = eos_shard_file_input_stream_wrapper_tell;
+  fileistream_klass->can_seek = eos_shard_file_input_stream_wrapper_can_seek;
+  fileistream_klass->seek = eos_shard_file_input_stream_wrapper_seek;
+  fileistream_klass->query_info = eos_shard_file_input_stream_wrapper_query_info;
+
+  obj_props[PROP_STREAM] =
+    g_param_spec_object ("stream", "", "",
+                         G_TYPE_INPUT_STREAM,
+                         (GParamFlags) (G_PARAM_READWRITE |
+                                        G_PARAM_CONSTRUCT_ONLY |
+                                        G_PARAM_STATIC_STRINGS));
+  obj_props[PROP_FILE] =
+    g_param_spec_object ("file", "", "",
+                         G_TYPE_OBJECT,
+                         (GParamFlags) (G_PARAM_READWRITE |
+                                        G_PARAM_CONSTRUCT_ONLY |
+                                        G_PARAM_STATIC_STRINGS));
+  g_object_class_install_properties (gobject_class, LAST_PROP, obj_props);
+}
+
+static void
+eos_shard_file_input_stream_wrapper_init (EosShardFileInputStreamWrapper *wrapper)
+{
+}
+
+GFileInputStream *
+_eos_shard_file_input_stream_wrapper_new (GFile *file, GInputStream *stream)
+{
+  g_return_val_if_fail (G_IS_FILE (file), NULL);
+  g_return_val_if_fail (G_IS_INPUT_STREAM (stream), NULL);
+
+  return g_object_new (EOS_SHARD_TYPE_FILE_INPUT_STREAM_WRAPPER,
+                       "file", file,
+                       "stream", stream,
+                       NULL);
+}

--- a/src/eos-shard-file-input-stream-wrapper.h
+++ b/src/eos-shard-file-input-stream-wrapper.h
@@ -1,0 +1,31 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+/*
+ * eos-shard-file-input-stream-wrapper.h
+ *
+ * Copyright (C) 2016 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+#define EOS_SHARD_TYPE_FILE_INPUT_STREAM_WRAPPER (eos_shard_file_input_stream_wrapper_get_type ())
+G_DECLARE_FINAL_TYPE (EosShardFileInputStreamWrapper, eos_shard_file_input_stream_wrapper, EOS_SHARD, FILE_INPUT_STREAM_WRAPPER, GFileInputStream)
+
+GFileInputStream *_eos_shard_file_input_stream_wrapper_new (GFile        *file,
+                                                            GInputStream *stream);

--- a/src/eos-shard-file.c
+++ b/src/eos-shard-file.c
@@ -1,0 +1,312 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+/*
+ * eos-shard-file.c
+ *
+ * Copyright (C) 2016 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Author: Juan Pablo Ugarte <ugarte@endlessm.com>
+ *
+ */
+
+#include "eos-shard-file.h"
+#include "eos-shard-file-input-stream-wrapper.h"
+
+#define EOS_SHARD_SCHEME_LEN 6
+
+struct _EosShardFile
+{
+  GObject parent;
+};
+
+typedef struct
+{
+  gchar *uri;
+  EosShardBlob *blob;
+} EosShardFilePrivate;
+
+enum
+{
+  PROP_0,
+
+  PROP_URI,
+  PROP_BLOB,
+  N_PROPERTIES
+};
+
+static GParamSpec *properties[N_PROPERTIES];
+
+static void eos_shard_file_iface_init (gpointer g_iface, gpointer iface_data);
+
+G_DEFINE_TYPE_EXTENDED (EosShardFile,
+			                  eos_shard_file,
+			                  G_TYPE_OBJECT, 0,
+			                  G_ADD_PRIVATE (EosShardFile)
+			                  G_IMPLEMENT_INTERFACE (G_TYPE_FILE,
+                                               eos_shard_file_iface_init))
+
+#define EOS_SHARD_FILE_PRIVATE(d) ((EosShardFilePrivate *) eos_shard_file_get_instance_private((EosShardFile*)d))
+
+static void
+eos_shard_file_init (EosShardFile *self)
+{
+
+}
+
+static void
+eos_shard_file_finalize (GObject *self)
+{
+  EosShardFilePrivate *priv = EOS_SHARD_FILE_PRIVATE (self);
+
+  g_clear_pointer (&priv->uri, g_free);
+  g_clear_pointer (&priv->blob, eos_shard_blob_unref);
+  
+  G_OBJECT_CLASS (eos_shard_file_parent_class)->finalize (self);
+}
+
+static inline void
+eos_shard_file_set_uri (EosShardFile *self, const gchar *uri)
+{
+  EosShardFilePrivate *priv = EOS_SHARD_FILE_PRIVATE (self);
+
+  g_return_if_fail (g_str_has_prefix (uri, "ekn:"));
+
+  if (g_strcmp0 (priv->uri, uri) != 0)
+    {
+      g_free (priv->uri);
+      priv->uri = g_strdup (uri);
+      g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_URI]);
+    }
+}
+
+static inline void
+eos_shard_file_set_blob (EosShardFile *self, EosShardBlob *blob)
+{
+  EosShardFilePrivate *priv = EOS_SHARD_FILE_PRIVATE (self);
+
+  g_clear_pointer (&priv->blob, eos_shard_blob_unref);
+  
+  if (blob)
+    priv->blob = eos_shard_blob_ref (blob);
+
+  g_object_notify_by_pspec (G_OBJECT (self), properties[PROP_BLOB]);
+}
+
+static void
+eos_shard_file_set_property (GObject      *self,
+                             guint         prop_id,
+                             const GValue *value,
+                             GParamSpec   *pspec)
+{
+  g_return_if_fail (EOS_SHARD_IS_FILE (self));
+
+  switch (prop_id)
+    {
+    case PROP_URI:
+      eos_shard_file_set_uri (EOS_SHARD_FILE (self), g_value_get_string (value));
+      break;
+    case PROP_BLOB:
+      eos_shard_file_set_blob (EOS_SHARD_FILE (self), g_value_get_pointer (value));
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (self, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+eos_shard_file_get_property (GObject    *self,
+                             guint       prop_id,
+                             GValue     *value,
+                             GParamSpec *pspec)
+{
+  EosShardFilePrivate *priv;
+
+  g_return_if_fail (EOS_SHARD_IS_FILE (self));
+  priv = EOS_SHARD_FILE_PRIVATE (self);
+
+  switch (prop_id)
+    {
+    case PROP_URI:
+      g_value_set_string (value, priv->uri);
+      break;
+    case PROP_BLOB:
+      g_value_set_pointer (value, priv->blob);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (self, prop_id, pspec);
+      break;
+    }
+}
+
+/* GFile iface implementation */
+
+static GFile *
+eos_shard_file_dup (GFile *self)
+{
+  EosShardFilePrivate *priv = EOS_SHARD_FILE_PRIVATE (self);
+  return eos_shard_file_new (priv->uri, priv->blob);
+}
+
+static guint
+eos_shard_file_hash (GFile *self)
+{
+  return g_str_hash (EOS_SHARD_FILE_PRIVATE (self)->uri);
+}
+
+static gboolean
+eos_shard_file_equal (GFile *file1, GFile *file2)
+{
+  return g_str_equal (EOS_SHARD_FILE_PRIVATE (file1)->uri, EOS_SHARD_FILE_PRIVATE (file2)->uri);
+}
+
+static gboolean
+eos_shard_file_is_native (GFile *self)
+{
+  return TRUE;
+}
+
+static gboolean 
+eos_shard_file_has_uri_scheme (GFile *self, const char *uri_scheme)
+{
+  return g_str_equal ("ekn", uri_scheme);
+}
+
+static char *
+eos_shard_file_get_uri_scheme (GFile *self)
+{
+  return g_strdup ("ekn");
+}
+
+static char *
+eos_shard_file_get_basename (GFile *self)
+{
+  EosShardFilePrivate *priv = EOS_SHARD_FILE_PRIVATE (self);
+  return priv->uri ? g_path_get_basename (priv->uri + EOS_SHARD_SCHEME_LEN) : NULL;
+}
+
+static char *
+eos_shard_file_get_path (GFile *self)
+{
+  EosShardFilePrivate *priv = EOS_SHARD_FILE_PRIVATE (self);
+  return priv->uri ? g_strdup (priv->uri + EOS_SHARD_SCHEME_LEN) : NULL;
+}
+
+static char *
+eos_shard_file_get_uri (GFile *self)
+{
+  return g_strdup (EOS_SHARD_FILE_PRIVATE (self)->uri);
+}
+
+static char *
+eos_shard_file_get_parse_name (GFile *self)
+{
+  return g_strdup (EOS_SHARD_FILE_PRIVATE (self)->uri);
+}
+
+static GFile *
+eos_shard_file_get_parent (GFile *self)
+{
+  return NULL;
+}
+
+static GFileInfo *
+eos_shard_file_query_info (GFile                *self,
+                           const char           *attributes,
+                           GFileQueryInfoFlags   flags,
+                           GCancellable         *cancellable,
+                           GError              **error)
+{
+  EosShardFilePrivate *priv = EOS_SHARD_FILE_PRIVATE (self);
+  GFileAttributeMatcher *matcher;
+  GFileInfo *info;
+
+  info    = g_file_info_new ();
+  matcher = g_file_attribute_matcher_new (attributes);
+
+  if (g_file_attribute_matcher_matches (matcher, G_FILE_ATTRIBUTE_STANDARD_SIZE))
+    g_file_info_set_size (info, eos_shard_blob_get_content_size (priv->blob));
+
+  if (g_file_attribute_matcher_matches (matcher, G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE))
+    g_file_info_set_content_type (info, eos_shard_blob_get_content_type (priv->blob));
+
+  g_file_attribute_matcher_unref (matcher);
+
+  return info;
+}
+
+static GFileInputStream *
+eos_shard_file_read_fn (GFile *self, GCancellable *cancellable, GError **error)
+{
+  GInputStream *stream = eos_shard_blob_get_stream (EOS_SHARD_FILE_PRIVATE (self)->blob);
+  return _eos_shard_file_input_stream_wrapper_new (self, stream);
+}
+
+static void
+eos_shard_file_iface_init (gpointer g_iface, gpointer iface_data)
+{
+  GFileIface *iface = g_iface;
+
+  iface->dup            = eos_shard_file_dup;
+  iface->hash           = eos_shard_file_hash;
+  iface->equal          = eos_shard_file_equal;
+  iface->is_native      = eos_shard_file_is_native;
+  iface->has_uri_scheme = eos_shard_file_has_uri_scheme;
+  iface->get_uri_scheme = eos_shard_file_get_uri_scheme;
+  iface->get_basename   = eos_shard_file_get_basename;
+  iface->get_path       = eos_shard_file_get_path;
+  iface->get_uri        = eos_shard_file_get_uri;
+  iface->get_parse_name = eos_shard_file_get_parse_name;
+  iface->get_parent     = eos_shard_file_get_parent;
+  iface->query_info     = eos_shard_file_query_info;
+  iface->read_fn        = eos_shard_file_read_fn;
+}
+
+static void
+eos_shard_file_class_init (EosShardFileClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize     = eos_shard_file_finalize;
+  object_class->get_property = eos_shard_file_get_property;
+  object_class->set_property = eos_shard_file_set_property;
+
+  /* Properties */
+  properties[PROP_URI] =
+    g_param_spec_string ("uri",
+                         "URI",
+                         "EOS Knowledge URI",
+                         NULL,
+                         G_PARAM_READWRITE |
+                         G_PARAM_CONSTRUCT_ONLY |
+                         G_PARAM_STATIC_STRINGS);
+
+  properties[PROP_BLOB] =
+    g_param_spec_pointer ("blob",
+                          "Blob",
+                          "EosShardBlob for uri",
+                          G_PARAM_READWRITE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (object_class, N_PROPERTIES, properties);
+}
+
+GFile *
+eos_shard_file_new (const gchar *uri, EosShardBlob *blob)
+{
+  return g_object_new (EOS_SHARD_TYPE_FILE, "uri", uri, "blob", blob, NULL);
+}

--- a/src/eos-shard-file.h
+++ b/src/eos-shard-file.h
@@ -1,0 +1,47 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*- */
+/*
+ * eos-shard-file.h
+ *
+ * Copyright (C) 2016 Endless Mobile, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * Author: Juan Pablo Ugarte <ugarte@endlessm.com>
+ *
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include "eos-shard-blob.h"
+
+G_BEGIN_DECLS
+
+#define EOS_SHARD_TYPE_FILE (eos_shard_file_get_type ())
+G_DECLARE_FINAL_TYPE (EosShardFile, eos_shard_file, EOS_SHARD, FILE, GObject)
+
+/**
+ * eos_shard_file_new:
+ * @uri: The URI to create this #GFile at.
+ * @blob: An #EosShardBlob to read for this file (transfer full)
+ *
+ * Creates a new #GFile with support for reading #EosShardBlob
+ * with the URI of uri.
+ *
+ * Returns: (transfer full): A #GFile implementation to read the shard
+ */
+GFile *eos_shard_file_new (const gchar *uri, EosShardBlob *blob);
+
+G_END_DECLS

--- a/src/eos-shard-file.h
+++ b/src/eos-shard-file.h
@@ -35,6 +35,7 @@ G_DECLARE_FINAL_TYPE (EosShardFile, eos_shard_file, EOS_SHARD, FILE, GObject)
 /**
  * eos_shard_file_new:
  * @uri: The URI to create this #GFile at.
+ * @uri_scheme: The URI scheme to use.
  * @blob: An #EosShardBlob to read for this file (transfer full)
  *
  * Creates a new #GFile with support for reading #EosShardBlob
@@ -42,6 +43,8 @@ G_DECLARE_FINAL_TYPE (EosShardFile, eos_shard_file, EOS_SHARD, FILE, GObject)
  *
  * Returns: (transfer full): A #GFile implementation to read the shard
  */
-GFile *eos_shard_file_new (const gchar *uri, EosShardBlob *blob);
+GFile *eos_shard_file_new (const gchar *uri,
+                           const gchar *uri_scheme,
+                           EosShardBlob *blob);
 
 G_END_DECLS


### PR DESCRIPTION
Pushing down the GFile implementation allows us to use it from places that cannot depend on Eknc, whilst simplifying the usage of shard files generally.

https://phabricator.endlessm.com/T16775