### PR TITLE
Don't typedef GObject structs twice

### DIFF
--- a/src/eos-shard-blob-stream.h
+++ b/src/eos-shard-blob-stream.h
@@ -22,6 +22,7 @@
 #include <gio/gio.h>
 
 #include "eos-shard-types.h"
+#include "eos-shard-shard-file.h"
 
 /**
  * EosShardBlobStream:

--- a/src/eos-shard-blob.h
+++ b/src/eos-shard-blob.h
@@ -24,6 +24,7 @@
 
 #include "eos-shard-types.h"
 #include "eos-shard-blob-stream.h"
+#include "eos-shard-shard-file.h"
 
 typedef enum
 {

--- a/src/eos-shard-record.h
+++ b/src/eos-shard-record.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 
 #include "eos-shard-types.h"
+#include "eos-shard-shard-file.h"
 
 /**
  * EosShardRecord:

--- a/src/eos-shard-shard-file-impl-v1.h
+++ b/src/eos-shard-shard-file-impl-v1.h
@@ -21,6 +21,7 @@
 #define EOS_SHARD_SHARD_FILE_IMPL_V1_H
 
 #include "eos-shard-types.h"
+#include "eos-shard-shard-file.h"
 #include "eos-shard-shard-file-impl.h"
 
 #define EOS_SHARD_TYPE_SHARD_FILE_IMPL_V1 (eos_shard_shard_file_impl_v1_get_type ())

--- a/src/eos-shard-shard-file-impl-v2.h
+++ b/src/eos-shard-shard-file-impl-v2.h
@@ -21,6 +21,7 @@
 #define EOS_SHARD_SHARD_FILE_IMPL_V2_H
 
 #include "eos-shard-types.h"
+#include "eos-shard-shard-file.h"
 #include "eos-shard-shard-file-impl.h"
 
 #define EOS_SHARD_TYPE_SHARD_FILE_IMPL_V2 (eos_shard_shard_file_impl_v2_get_type ())

--- a/src/eos-shard-types.h
+++ b/src/eos-shard-types.h
@@ -19,10 +19,7 @@
 
 #pragma once
 
-typedef struct _EosShardShardFile EosShardShardFile;
-typedef struct _EosShardShardFileImpl EosShardShardFileImpl;
 typedef struct _EosShardRecord EosShardRecord;
 typedef struct _EosShardBlob EosShardBlob;
-typedef struct _EosShardBlobStream EosShardBlobStream;
 typedef struct _EosShardDictionary EosShardDictionary;
 typedef struct _EosShardDictionaryWriter EosShardDictionaryWriter;


### PR DESCRIPTION
Discovered while splitting out ekncontent into a separate library -
compiling it with Meson's default warnings points out that
G_DECLARE_*_TYPE already emits these typedefs, so we are actually doing
the same typedef twice.

https://phabricator.endlessm.com/T21655