### PR TITLE
Initialize g_autoptr variables to NULL

### DIFF
--- a/src/eos-shard-shard-file.c
+++ b/src/eos-shard-shard-file.c
@@ -449,9 +449,9 @@ _eos_shard_shard_file_load_blob (EosShardShardFile *self, EosShardBlob *blob, GE
   }
 
   if (blob->flags & EOS_SHARD_BLOB_FLAG_COMPRESSED_ZLIB) {
-    g_autoptr(GInputStream) bytestream;
-    g_autoptr(GZlibDecompressor) decompressor;
-    g_autoptr(GInputStream) out_stream;
+    g_autoptr(GInputStream) bytestream = NULL;
+    g_autoptr(GZlibDecompressor) decompressor = NULL;
+    g_autoptr(GInputStream) out_stream = NULL;
 
     decompressor = g_zlib_decompressor_new (G_ZLIB_COMPRESSOR_FORMAT_ZLIB);
     bytestream = g_memory_input_stream_new_from_bytes (bytes);

--- a/src/eos-shard-writer-v1.c
+++ b/src/eos-shard-writer-v1.c
@@ -195,7 +195,7 @@ write_blob (int fd, struct eos_shard_writer_v1_blob_entry *blob)
     return;
   }
 
-  g_autoptr(GInputStream) stream;
+  g_autoptr(GInputStream) stream = NULL;
 
   if (blob->flags & EOS_SHARD_BLOB_FLAG_COMPRESSED_ZLIB) {
     g_autoptr(GZlibCompressor) compressor = g_zlib_compressor_new (G_ZLIB_COMPRESSOR_FORMAT_ZLIB, -1);


### PR DESCRIPTION
In GLib 2.56.x, g_autoptr warns unless the variable is assigned a value
unconditionally.